### PR TITLE
Implement discard function for revertibles

### DIFF
--- a/packages/dds/sequence/src/revertibles.ts
+++ b/packages/dds/sequence/src/revertibles.ts
@@ -7,6 +7,7 @@
 import { assert, unreachableCase } from "@fluidframework/common-utils";
 import {
 	appendToMergeTreeDeltaRevertibles,
+	discardMergeTreeDeltaRevertible,
 	isMergeTreeDeltaRevertible,
 	LocalReferencePosition,
 	MergeTreeDeltaOperationType,
@@ -260,6 +261,24 @@ export function appendSharedStringDeltaToRevertibles(
 	}
 	appendToMergeTreeDeltaRevertibles(string, delta.deltaArgs, mergeTreeRevertibles);
 	revertibles.push(...mergeTreeRevertibles);
+}
+
+/**
+ * Clean up resources held by revertibles that are no longer needed.
+ * @alpha
+ */
+export function discardSharedStringRevertibles(
+	sharedString: SharedString,
+	revertibles: SharedStringRevertible[],
+) {
+	revertibles.forEach((r) => {
+		if (isMergeTreeDeltaRevertible(r)) {
+			discardMergeTreeDeltaRevertible([r]);
+		} else if (r.event === IntervalEventType.CHANGE || r.event === IntervalEventType.DELETE) {
+			sharedString.removeLocalReferencePosition(r.start);
+			sharedString.removeLocalReferencePosition(r.end);
+		}
+	});
 }
 
 // Uses of referenceRangeLabels will be removed once AB#4081 is completed.


### PR DESCRIPTION
Add a function to clean up shared string revertibles: this calls into the discard function for merge tree revertibles and removes local reverences from interval revertibles. Users of revertibles can call this when these revertibles are no longer actionable, to free up resources.