### PR TITLE
Fix interval edits + position remove revertible combos

### DIFF
--- a/api-report/sequence.api.md
+++ b/api-report/sequence.api.md
@@ -258,6 +258,11 @@ export type IntervalRevertible = {
         startOffset?: number;
         endOffset?: number;
     }[];
+    revertibleRefs: {
+        revertible: IntervalRevertible;
+        offset: number;
+        isStart: boolean;
+    }[];
     mergeTreeRevertible: MergeTreeDeltaRevertible;
 };
 

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -928,6 +928,29 @@ describe("Undo/redo for string remove containing intervals", () => {
 			assert.equal(sharedString.getText(), "hello world");
 			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
 		});
+		it("reverts interval change + remove range with interval start", () => {
+			sharedString.insertText(0, "hello world");
+			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();
+
+			sharedString.on("sequenceDelta", (op) => {
+				appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+			});
+			collection.on("changeInterval", (interval, previousInterval, local, op) => {
+				appendChangeIntervalToRevertibles(
+					sharedString,
+					interval,
+					previousInterval,
+					revertibles,
+				);
+			});
+
+			collection.change(id, 2, 9);
+			sharedString.removeRange(0, 8);
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
+		});
 		it("reverts remove range + interval change", () => {
 			sharedString.insertText(0, "hello world");
 			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -867,4 +867,89 @@ describe("Undo/redo for string remove containing intervals", () => {
 			{ start: 3, end: 7 },
 		]);
 	});
+
+	describe("mixed with direct interval edit revertibles", () => {
+		it("reverts interval delete + remove range", () => {
+			sharedString.insertText(0, "hello world");
+			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();
+
+			sharedString.on("sequenceDelta", (op) => {
+				appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+			});
+			collection.on("deleteInterval", (interval, local, op) => {
+				appendDeleteIntervalToRevertibles(sharedString, interval, revertibles);
+			});
+
+			collection.removeIntervalById(id);
+			sharedString.removeRange(0, 8);
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
+		});
+		it("reverts remove range + interval delete", () => {
+			sharedString.insertText(0, "hello world");
+			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();
+
+			sharedString.on("sequenceDelta", (op) => {
+				appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+			});
+			collection.on("deleteInterval", (interval, local, op) => {
+				appendDeleteIntervalToRevertibles(sharedString, interval, revertibles);
+			});
+
+			sharedString.removeRange(0, 8);
+			collection.removeIntervalById(id);
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
+		});
+		it("reverts interval change + remove range", () => {
+			sharedString.insertText(0, "hello world");
+			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();
+
+			sharedString.on("sequenceDelta", (op) => {
+				appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+			});
+			collection.on("changeInterval", (interval, previousInterval, local, op) => {
+				appendChangeIntervalToRevertibles(
+					sharedString,
+					interval,
+					previousInterval,
+					revertibles,
+				);
+			});
+
+			collection.change(id, 2, 4);
+			sharedString.removeRange(0, 8);
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
+		});
+		it("reverts remove range + interval change", () => {
+			sharedString.insertText(0, "hello world");
+			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();
+
+			sharedString.on("sequenceDelta", (op) => {
+				appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+			});
+			collection.on("changeInterval", (interval, previousInterval, local, op) => {
+				appendChangeIntervalToRevertibles(
+					sharedString,
+					interval,
+					previousInterval,
+					revertibles,
+				);
+			});
+
+			sharedString.removeRange(0, 8);
+			collection.change(id, 1, 2);
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
+		});
+	});
 });

--- a/packages/dds/sequence/src/test/revertibles.spec.ts
+++ b/packages/dds/sequence/src/test/revertibles.spec.ts
@@ -951,6 +951,29 @@ describe("Undo/redo for string remove containing intervals", () => {
 			assert.equal(sharedString.getText(), "hello world");
 			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
 		});
+		it("reverts interval change + remove range containing only revertible refs", () => {
+			sharedString.insertText(0, "hello world");
+			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();
+
+			sharedString.on("sequenceDelta", (op) => {
+				appendSharedStringDeltaToRevertibles(sharedString, op, revertibles);
+			});
+			collection.on("changeInterval", (interval, previousInterval, local, op) => {
+				appendChangeIntervalToRevertibles(
+					sharedString,
+					interval,
+					previousInterval,
+					revertibles,
+				);
+			});
+
+			collection.change(id, 9, 10);
+			sharedString.removeRange(0, 8);
+			revertSharedStringRevertibles(sharedString, revertibles.splice(0));
+
+			assert.equal(sharedString.getText(), "hello world");
+			assertIntervals(sharedString, collection, [{ start: 1, end: 5 }]);
+		});
 		it("reverts remove range + interval change", () => {
 			sharedString.insertText(0, "hello world");
 			const id = collection.add(1, 5, IntervalType.SlideOnRemove).getIntervalId();


### PR DESCRIPTION
Fixed bugs:
1. position-remove revertible wasn't checking the map of old to new ids for re-created intervals
2. local refs in revertibles for DELETE and CHANGE of intervals were left behind if the segment was deleted, but not added back to the recreated segments on revert

Added tests for interesting combinations of position-remove (i.e. string ranges deleted) + interval edit revertibles. This just covers interval change and delete. Interval add and property change revertibles are not covered since they're not really affected when the containing text is removed.